### PR TITLE
mental health resources plugin updates

### DIFF
--- a/index.md
+++ b/index.md
@@ -151,7 +151,7 @@ TABLE OF CONTENTS
 
 ### Mental health resources
 
-[<b>[Code]</b>](https://github.com/nivlab/jspsych-demos/tree/main/tasks/self-report) [<b>[Demo]</b>](./tasks/self-report/experiment.html?plugin=mha)
+[<b>[Code]</b>](https://github.com/nivlab/jspsych-demos/tree/main/tasks/self-report) [<b>[Demo]</b>](./tasks/self-report/experiment.html?plugin=mhr)
 
 > Displays a page with free-to-access mental health resources for participants. Must be included in any  online Niv/Daw lab experiment involving self-report symptom measures.
 

--- a/tasks/self-report/experiment.html
+++ b/tasks/self-report/experiment.html
@@ -13,7 +13,7 @@
   <script src="./plugin-survey-demo.js"></script>
   <script src="./plugin-survey-feedback.js"></script>
   <script src="./plugin-survey-template.js"></script>
-  <script src="./plugin-mental-health-alert.js"></script>
+  <script src="./plugin-mental-health-resources.js"></script>
 
   <!-- Load template surveys -->
   <script src="./surveys/7u7d.js"></script>
@@ -74,9 +74,9 @@
     type: jsPsychSurveyFeedback
   }
 
-  // Define mental health alert.
-  var MHA = {
-    type: jsPsychMentalHealthAlert
+  // Define mental health resources.
+  var MHR = {
+    type: jsPsychMentalHealthResources
   }
 
   // Define random survey.
@@ -140,8 +140,8 @@
     timeline = timeline.concat(FEEDBACK);
   } else if (show_plugin == "survey") {
     timeline = timeline.concat(SURVEY);
-  } else if (show_plugin == "mha") {
-    timeline = timeline.concat(MHA);
+  } else if (show_plugin == "mhr") {
+    timeline = timeline.concat(MHR);
   } else if (show_plugin == "checklist") {
     timeline = timeline.concat(CHECKLIST)
   } else {

--- a/tasks/self-report/plugin-mental-health-alert.js
+++ b/tasks/self-report/plugin-mental-health-alert.js
@@ -19,6 +19,8 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
   *
   * plugin for displaying mental health resources
   *
+  * authors: Sam Zorowitz, Yongjing Ren
+  *
   **/
   class MentalHealthAlertPlugin {
     constructor(jsPsych) {
@@ -35,41 +37,55 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
 
       // Insert CSS.
       html += `<style>
+      .jspsych-content {
+        max-width: 950px;
+        margin: 20px auto auto auto;
+        font-size: 17px;
+      }
       a:link {
         color: #29a3a3;
       }
-      .mental-health-wrap {
-        height: 100vh;
-        width: 100vw;
+      .button-row {
+        display: flex;
+        flex-direction: row;
+        column-gap: 10px;
+        margin-bottom: 100px;
       }
-      .mental-health-container {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        height: 80vh;
-        width: 70vw;
-        -webkit-transform: translate3d(-50%, -50%, 0);
-        transform: translate3d(-50%, -50%, 0);
+      .button-row button {
+        min-width: 96px;
+        min-height: 24px;
+        padding: 8px 12px 8px 12px;
+        font-size: 16px;
+        border: none;
+        border-radius: 4px;
+      }
+      .button-row button:hover {
+        filter: brightness(95%);
+        -webkit-filter: brightness(95%);
+      }
+      .resources {
+        display: none;
         text-align: left;
-        font-size: 1.33vw;
-        line-height: 1.5vw;
+        font-size: 17px;
+        line-height: 1.5em;
       }
-      .mental-health-container li {
-        margin: 0.7em 0;
+      .resources li:not(:last-child) {
+         margin-bottom: 5px;
       }
-      .mental-health-container input[type=submit] {
+      input[type=submit] {
         background-color: #F0F0F0;
         color: black;
         padding: 8px 20px;
         border: none;
         border-radius: 4px;
-        font-size: 1.15vw;
-        margin: 1.5vh 0 0 0;
+        font-size: 16px;
+        margin: 6px 0 6px 0;
+      }
+      input[type=submit]:hover {
+        filter: brightness(95%);
+        -webkit-filter: brightness(95%);
       }
       </style>`
-
-      // Initialize mental-health-container.
-      html += '<div class="mental-health-wrap"><div class="mental-health-container">';
 
       // Add paragraph 1.
       html += '<h3>Thank you for your honesty.</h3>'
@@ -80,8 +96,18 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
       html += '<p>If you are interested in learning more about mental health or in speaking to a professional, we have provided some resources below and on <a href="https://nivlab.princeton.edu/mental-health-resources" target="_blank">our website</a>. You may wish to screenshot this page for your reference.</p>'
       html += '<hr>';
 
+      // Add button row.
+      html += '<div class="button-row" id="button-row">';
+      html += '<div>Resources by country:</div>';
+      html += '<button id="button-us">United States</button>';
+      html += '<button id="button-canada">Canada</button>';
+      html += '<button id="button-australia">Australia</button>';
+      html += '<button id="button-new-zealand">New Zealand</button>';
+      html += '<button id="button-other">Other countries</button>';
+      html += '</div>';
+
       // US resources
-      html += '<p>For resources in <b>the US</b>:</p>';
+      html += '<div class="resources" id="us-resources">';
       html += '<ul>';
       html += '<li>To learn more about mental health conditions, treatment, research, and warning signs, you can visit the <a href="https://www.nami.org/Learn-More" target="_blank">NAMI site</a>.</li>';
       html += '<li>If the questions you answered trouble you in any way, we urge you to arrange a timely appointment with your physician, clinical psychologist or psychiatrist.</li>';
@@ -90,18 +116,20 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
       html += '<li style="font-size: 1.25vw; margin: 0.3em 0 0 0">The <a href="https://suicidepreventionlifeline.org/chat" target="_blank">Lifeline Crisis chat</a></li>';
       html += '<li style="font-size: 1.25vw; margin: 0.3em 0 0 0">The <a href="http://suicidepreventionlifeline.org" target="_blank">National Suicide Prevention Hotline</a> (or call: 1-800-273-8255)</li>';
       html += '</ul></ul>';
+      html += '</div>';
 
       // Canada resources
-      html += '<p>For resources in <b>Canada</b>:</p>';
+      html += '<div class="resources" id="canada-resources">';
       html += '<ul>';
       html += '<li>To learn more about mental health conditions, treatment, research, and warning signs, you can visit the <a href="https://cmha.ca/find-info/mental-health/" target="_blank">CMHA site</a>.</li>';
       html += '<li>If the questions you answered trouble you in any way, we urge you to arrange a timely appointment with your physician, clinical psychologist or psychiatrist.</li>';
       html += '<li>For help finding a mental health services, you can visit <a href="https://www.camh.ca/en/health-info/guides-and-publications/looking-for-mental-health-services" target="_blank">CAMH page on looking for mental health services</a>, and/or the <a href="https://cmha.ca/find-help/how-to-get-help/" target="_blank">CMHA page on how to get help</a>.</li>';
       html += '<li>A number of organizations offer support during difficult times. For example, for free support network in Canada, you can visit <a href="https://talksuicide.ca/" target="_blank">talksuicide.ca</a> or call 1-833-456-4566 (1-866-277-3553 in Quebec)</li>';
       html += '</ul>';
+      html += '</div>';
 
       // Australia resources
-      html += '<p>For resources in <b>Australia</b>:</p>';
+      html += '<div class="resources" id="australia-resources">';
       html += '<ul>';
       html += '<li>To learn more about mental health conditions, treatment, research, and warning signs, you can visit the <a href="https://www.healthdirect.gov.au/mental-illness" target="_blank">healthdirect site</a>.</li>';
       html += '<li>If the questions you answered trouble you in any way, we urge you to arrange a timely appointment with your physician, clinical psychologist or psychiatrist.</li>';
@@ -110,9 +138,10 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
       html += '<li style="font-size: 1.25vw; margin: 0.3em 0 0 0">The <a href="https://www.lifeline.org.au/" target="_blank">Lifeline crisis support</a> (or call 13 11 14)</li>';
       html += '<li style="font-size: 1.25vw; margin: 0.3em 0 0 0">The <a href="https://www.suicidecallbackservice.org.au/" target="_blank">Suicide Call Back Service</a> (or call 1300 659 467)</li>';
       html += '</ul></ul></ul>';
+      html += '</div>';
 
       // New Zealand resources
-      html += '<p>For resources in <b>New Zealand</b>:</p>';
+      html += '<div class="resources" id="new-zealand-resources">';
       html += '<ul>';
       html += '<li>To learn more about mental health conditions, treatment, research, and warning signs, you can visit the <a href="https://mentalhealth.org.nz/what-is-wellbeing" target="_blank">Mental Health Foundation site</a>.</li>';
       html += '<li>If the questions you answered trouble you in any way, we urge you to arrange a timely appointment with your physician, clinical psychologist or psychiatrist.</li>';
@@ -121,21 +150,19 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
       html += '<li style="font-size: 1.25vw; margin: 0.3em 0 0 0">The <a href="https://www.lifeline.org.nz/" target="_blank">Lifeline</a> (or call 0800 543 354)</li>';
       html += '<li style="font-size: 1.25vw; margin: 0.3em 0 0 0">The <a href="https://www.samaritans.org.nz/" target="_blank">Samaritans</a> (or call: 0800 726 666)</li>';
       html += '</ul></ul>';
+      html += '</div>';
 
       // Other location resources
-      html += '<p>For resources in <b>other countries</b>:</p>';
+      html += '<div class="resources" id="other-resources">';
       html += '<ul>';
       html += '<li>We have provided resources in the countries where most of our participants come from, but for any other country please search <i>"(name of your country) mental health support/services"</i> in Google to find resources close to you</a>.</li>';
       html += '</ul>';
-
-      // Begin form.
-      html += '<form id="jspsych-mental-health-alert">';
+      html += '</div>';
 
       // Add submit button
+      html += '<form id="jspsych-mental-health-alert">';
       html += `<center><input type="submit" id="jspsych-mental-health-alert" value="${trial.button_label}"></input><center>`;
-
-      // End form
-      html += '</form></div></div>';
+      html += '</form>';
 
       // Display HTML.
       display_element.innerHTML = html;
@@ -149,6 +176,33 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
         window.scrollTo(0, 0);
       }
 
+      // Define convenience functions
+      function hideAllResources() {
+        document.getElementById('us-resources').style.display = 'none';
+        document.getElementById('button-us').style.background = '#F0F0F0';
+        document.getElementById('canada-resources').style.display = 'none';
+        document.getElementById('button-canada').style.background = '#F0F0F0';
+        document.getElementById('australia-resources').style.display = 'none';
+        document.getElementById('button-australia').style.background = '#F0F0F0';
+        document.getElementById('new-zealand-resources').style.display = 'none';
+        document.getElementById('button-new-zealand').style.background = '#F0F0F0';
+        document.getElementById('other-resources').style.display = 'none';
+        document.getElementById('button-other').style.background = '#F0F0F0';
+      }
+
+      function showResources(country) {
+        document.getElementById(country + '-resources').style.display = 'block';
+        document.getElementById('button-' + country).style.background = '#a4d4d4';
+        document.getElementById('button-row').style['margin-bottom'] = '0';
+      }
+
+      // Define button event listeners
+      ['us', 'canada', 'australia', 'new-zealand', 'other'].forEach(country => {
+        document.getElementById('button-' + country).addEventListener('click', function() {
+          hideAllResources(); showResources(country);
+        });
+      });
+
       display_element.querySelector('#jspsych-mental-health-alert').addEventListener('submit', function(event) {
 
         // Wait for response
@@ -157,7 +211,6 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
         // Measure response time
         var endTime = performance.now();
         var response_time = endTime - startTime;
-
 
         // Store data
         var trialdata = {

--- a/tasks/self-report/plugin-mental-health-alert.js
+++ b/tasks/self-report/plugin-mental-health-alert.js
@@ -77,7 +77,7 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
       html += '<p>As a reminder, your responses to the questionnaires will remain strictly anonymous. Your identity is not known to the experimenters.</p>'
 
       // Add paragraph 2.
-      html += '<p>If you are interested in learning more about mental health or in speaking to a professional, we have provided some resources below and on <a href="https://nivlab.princeton.edu/mental-health-resources">our website</a>. You may wish to screenshot this page for your reference.</p>'
+      html += '<p>If you are interested in learning more about mental health or in speaking to a professional, we have provided some resources below and on <a href="https://nivlab.princeton.edu/mental-health-resources" target="_blank">our website</a>. You may wish to screenshot this page for your reference.</p>'
       html += '<hr>';
 
       // US resources

--- a/tasks/self-report/plugin-mental-health-resources.js
+++ b/tasks/self-report/plugin-mental-health-resources.js
@@ -5,6 +5,12 @@ var jsPsychMentalHealthResources = (function (jspsych) {
     name: 'mental-health-resources',
     description: '',
     parameters: {
+      country: {
+        type: jspsych.ParameterType.STRING,
+        pretty_name: 'Country',
+        default: 'us',
+        description: 'The country for which resources are first shown (us, canada, australia, new-zealand, other).'
+      },
       button_label: {
         type: jspsych.ParameterType.STRING,
         pretty_name: 'Button label',
@@ -197,7 +203,7 @@ var jsPsychMentalHealthResources = (function (jspsych) {
       }
 
       // Start with US resources
-      showResources('us');  
+      showResources(trial.country);
 
       // Define button event listeners
       ['us', 'canada', 'australia', 'new-zealand', 'other'].forEach(country => {

--- a/tasks/self-report/plugin-mental-health-resources.js
+++ b/tasks/self-report/plugin-mental-health-resources.js
@@ -196,6 +196,9 @@ var jsPsychMentalHealthResources = (function (jspsych) {
         document.getElementById('button-row').style['margin-bottom'] = '0';
       }
 
+      // Start with US resources
+      showResources('us');  
+
       // Define button event listeners
       ['us', 'canada', 'australia', 'new-zealand', 'other'].forEach(country => {
         document.getElementById('button-' + country).addEventListener('click', function() {

--- a/tasks/self-report/plugin-mental-health-resources.js
+++ b/tasks/self-report/plugin-mental-health-resources.js
@@ -202,11 +202,16 @@ var jsPsychMentalHealthResources = (function (jspsych) {
         document.getElementById('button-row').style['margin-bottom'] = '0';
       }
 
+      // Define list of countries.
+      const countries = ['us', 'canada', 'australia', 'new-zealand', 'other'];
+
       // Initialize resources
-      showResources(trial.country);
+      if (countries.includes(trial.country.toLowerCase())) {
+        showResources(trial.country.toLowerCase());
+      };
 
       // Define button event listeners
-      ['us', 'canada', 'australia', 'new-zealand', 'other'].forEach(country => {
+      countries.forEach(country => {
         document.getElementById('button-' + country).addEventListener('click', function() {
           hideAllResources(); showResources(country);
         });

--- a/tasks/self-report/plugin-mental-health-resources.js
+++ b/tasks/self-report/plugin-mental-health-resources.js
@@ -202,7 +202,7 @@ var jsPsychMentalHealthResources = (function (jspsych) {
         document.getElementById('button-row').style['margin-bottom'] = '0';
       }
 
-      // Start with US resources
+      // Initialize resources
       showResources(trial.country);
 
       // Define button event listeners

--- a/tasks/self-report/plugin-mental-health-resources.js
+++ b/tasks/self-report/plugin-mental-health-resources.js
@@ -1,8 +1,8 @@
-var jsPsychMentalHealthAlert = (function (jspsych) {
+var jsPsychMentalHealthResources = (function (jspsych) {
   'use strict';
 
   const info = {
-    name: 'mental-health-alert',
+    name: 'mental-health-resources',
     description: '',
     parameters: {
       button_label: {
@@ -15,14 +15,14 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
   }
 
   /**
-  * jspsych-mental-health-alert
+  * jspsych-mental-health-resources
   *
   * plugin for displaying mental health resources
   *
   * authors: Sam Zorowitz, Yongjing Ren
   *
   **/
-  class MentalHealthAlertPlugin {
+  class MentalHealthResourcesPlugin {
     constructor(jsPsych) {
       this.jsPsych = jsPsych;
     }
@@ -160,8 +160,8 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
       html += '</div>';
 
       // Add submit button
-      html += '<form id="jspsych-mental-health-alert">';
-      html += `<center><input type="submit" id="jspsych-mental-health-alert" value="${trial.button_label}"></input><center>`;
+      html += '<form id="jspsych-mental-health-resources">';
+      html += `<center><input type="submit" id="jspsych-mental-health-resources" value="${trial.button_label}"></input><center>`;
       html += '</form>';
 
       // Display HTML.
@@ -203,7 +203,7 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
         });
       });
 
-      display_element.querySelector('#jspsych-mental-health-alert').addEventListener('submit', function(event) {
+      display_element.querySelector('#jspsych-mental-health-resources').addEventListener('submit', function(event) {
 
         // Wait for response
         event.preventDefault();
@@ -229,8 +229,8 @@ var jsPsychMentalHealthAlert = (function (jspsych) {
 
     };
   }
-  MentalHealthAlertPlugin.info = info;
+  MentalHealthResourcesPlugin.info = info;
 
-  return MentalHealthAlertPlugin;
+  return MentalHealthResourcesPlugin;
 
 })(jsPsychModule);


### PR DESCRIPTION
Some major and minor modifications of the mental health resources plugin. 

## Major
- Rename the plugin from "mental-health-alert" to "mental-health-resources". This just makes more sense.
- Link to Niv lab website now opens in new tab. This prevents users from accidentally restarting the experiment.

## Minor
- Hide all resources on load.
- Added buttons with country labels. Participants now select their country of residence, and the corresponding resources show. 
- Minor simplification of the plugin CSS (e.g., removed all wrapper classes, simplified font scaling).

@YJ-Ren, would you mind taking a look and seeing what you think? 